### PR TITLE
Fix relative image reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://api.travis-ci.com/hetio/xswap.svg?branch=master)
 
-<img src="docs/img/xswap.svg" width="250px">
+<img src="https://raw.githubusercontent.com/hetio/xswap/master/docs/img/xswap.svg?sanitize=true" width="250px">
 
 XSwap is an algorithm for degree-preserving network randomization (permutation) [1].
 Permuted networks can be used for a number of purposes in network analysis, including for generating counterfactual distributions of features when only the network's degree sequence is maintained or for computing a prior probability of an edge given only the network's degree sequence.


### PR DESCRIPTION
Our PyPI page does not show the XSwap image because it uses a relative link

See:
![image](https://user-images.githubusercontent.com/7230303/62300148-4af72f00-b444-11e9-9a31-253519843fe1.png)
https://pypi.org/project/xswap/#description