### PR TITLE
Add project_urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,12 @@ setuptools.setup(
     name='xswap',
     version=version,
     url='https://github.com/greenelab/xswap',
+    project_urls={
+        'Documentation': 'https://hetio.github.io/xswap/',
+        'Source': 'https://github.com/hetio/xswap',
+        'Tracker': 'https://github.com/hetio/xswap/issues',
+        'Publication': 'https://greenelab.github.io/xswap-manuscript/',
+    },
     description='Python-wrapped C/C++ library for degree-preserving network randomization',
     long_description_content_type='text/markdown',
     long_description=long_description,


### PR DESCRIPTION
Enables links to show up on PyPI
https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls

example:
https://github.com/pdoc3/pdoc/blob/9d71e3269f32c00828d7698d07ca2df0ef8007cc/setup.py#L22-L26

> ![image](https://user-images.githubusercontent.com/1117703/63782349-45f99400-c8b9-11e9-9dcb-b410ffb5ff18.png)
